### PR TITLE
MMM-23 & MMM-42: Progress Start and Breaking Components

### DIFF
--- a/.idea/.idea.MMM/.idea/.gitignore
+++ b/.idea/.idea.MMM/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/projectSettingsUpdater.xml
+/contentModel.xml
+/.idea.MMM.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.MMM/.idea/encodings.xml
+++ b/.idea/.idea.MMM/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.MMM/.idea/indexLayout.xml
+++ b/.idea/.idea.MMM/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.MMM/.idea/vcs.xml
+++ b/.idea/.idea.MMM/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/Assets/Managers/ActManager/ActManager.cs
+++ b/Assets/Managers/ActManager/ActManager.cs
@@ -86,11 +86,13 @@ public class ActManager : MonoBehaviour
             }
         }
 
-        allComponentsStarted = true;
-        foreach (MechComponent component in componentList)
-        {
-            if (component.mechComponentState == MechComponent.MechComponentState.NotStarted){
-                allComponentsStarted = false;
+        if (!allComponentsStarted){
+            allComponentsStarted = true;
+            foreach (MechComponent component in componentList)
+            {
+                if (component.mechComponentState != MechComponent.MechComponentState.Running){
+                    allComponentsStarted = false;
+                }
             }
         }
         

--- a/Assets/Managers/ActManager/ActManager.cs
+++ b/Assets/Managers/ActManager/ActManager.cs
@@ -42,6 +42,7 @@ public class ActManager : MonoBehaviour
     [SerializeField]
     private int progressCounter = 0;
 
+    private bool allComponentsStarted = false;
 
     public enum ActState { Playing, Won, Lost };
     [SerializeField]
@@ -85,6 +86,14 @@ public class ActManager : MonoBehaviour
             }
         }
 
+        allComponentsStarted = true;
+        foreach (MechComponent component in componentList)
+        {
+            if (component.mechComponentState == MechComponent.MechComponentState.NotStarted){
+                allComponentsStarted = false;
+            }
+        }
+        
     }
 
 
@@ -103,6 +112,10 @@ public class ActManager : MonoBehaviour
     void UpdateProgress()
     {
 
+        if (!allComponentsStarted){
+            return;
+        }
+        
         foreach (MechComponent component in componentList)
         {
             if (component.GetState() == MechComponent.MechComponentState.Running)

--- a/Assets/MechComponents/MechComponent.cs
+++ b/Assets/MechComponents/MechComponent.cs
@@ -9,6 +9,19 @@ public abstract class MechComponent : MonoBehaviour
     public enum MechComponentState { NotStarted, Running, Broken };
     [SerializeField]
     public MechComponentState mechComponentState = MechComponentState.NotStarted;
+    
+    [SerializeField]
+    private float currentBreakTime = 0.0f;
+    [SerializeField]
+    private float minBreakTime = 1.0f;
+    [SerializeField]
+    private float maxBreakTime = 2.0f;
+    private float targetBreakTime = 2.0f;
+    
+    [SerializeField]
+    private float smokingTimeThreshold = 1.0f; // The last 1 second is when to start smoking.
+    private bool isSmoking = false;
+        
 
     public virtual bool StartComponent()
     {
@@ -21,6 +34,7 @@ public abstract class MechComponent : MonoBehaviour
         return true;
     }
 
+    
     public virtual bool Fix()
     {
         if (mechComponentState != MechComponentState.Broken)
@@ -42,15 +56,54 @@ public abstract class MechComponent : MonoBehaviour
             return false;
         }
         mechComponentState = MechComponentState.Broken;
+        
+        isSmoking = false;
+        currentBreakTime = 0.0f;
+        StopSmoking();
+        SetNewBreakTarget();
+        
         return true;
     }
 
+    
     public virtual void ResetComponent()
     {
         mechComponentState = MechComponentState.NotStarted;
     }
+    
+    
+    public virtual void Update()
+    {
+        if (mechComponentState == MechComponentState.Running){
+            UpdateBreakTimer();
+        }
+    }
 
+    public abstract void StartSmoking();
+    public abstract void StopSmoking();
+    
+    private void UpdateBreakTimer()
+    {
+        currentBreakTime += Time.deltaTime;
 
+        if ( currentBreakTime > (targetBreakTime - smokingTimeThreshold) ){
+            if (!isSmoking){
+                StartSmoking();
+            }
+            isSmoking = true;
+        }
+        if ( currentBreakTime < targetBreakTime ){
+            return;
+        }
+
+        Break();
+    }
+
+    private void SetNewBreakTarget()
+    {
+        targetBreakTime = Random.Range(minBreakTime, maxBreakTime);
+    }
+    
     public MechComponentState GetState()
     {
         return mechComponentState;

--- a/Assets/MechComponents/MechComponent.cs
+++ b/Assets/MechComponents/MechComponent.cs
@@ -42,7 +42,9 @@ public abstract class MechComponent : MonoBehaviour
             Debug.LogError("Cannot Fix() this component unless it's Broken!");
             return false;
         }
-
+        
+        SetNewBreakTarget();
+        
         mechComponentState = MechComponentState.Running;
         return true;
     }
@@ -60,7 +62,6 @@ public abstract class MechComponent : MonoBehaviour
         isSmoking = false;
         currentBreakTime = 0.0f;
         StopSmoking();
-        SetNewBreakTarget();
         
         return true;
     }

--- a/Assets/MechComponents/MechComponent.cs
+++ b/Assets/MechComponents/MechComponent.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
+using Random = UnityEngine.Random;
 
 
 public abstract class MechComponent : MonoBehaviour
@@ -21,7 +23,11 @@ public abstract class MechComponent : MonoBehaviour
     [SerializeField]
     private float smokingTimeThreshold = 1.0f; // The last 1 second is when to start smoking.
     private bool isSmoking = false;
-        
+
+    public void Start()
+    {
+        SetNewBreakTarget();
+    }
 
     public virtual bool StartComponent()
     {

--- a/Assets/MechComponents/Prefabs/ExampleComponent.prefab
+++ b/Assets/MechComponents/Prefabs/ExampleComponent.prefab
@@ -30,7 +30,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1600255250204407696
 MonoBehaviour:
@@ -44,3 +44,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1f94dad191ac51147b85744cefee166e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  mechComponentState: 0
+  currentBreakTime: 0
+  minBreakTime: 6
+  maxBreakTime: 10
+  smokingTimeThreshold: 5
+  isSmoking: 0

--- a/Assets/MechComponents/Scripts/ExampleComponent.cs
+++ b/Assets/MechComponents/Scripts/ExampleComponent.cs
@@ -50,4 +50,16 @@ public class ExampleComponent : MechComponent
         Debug.Log("Reset ExampleComponent!");
     }
 
+    
+    
+    public override void StartSmoking()
+    {
+        Debug.Log("Started Smoking!");
+    }
+    
+    public override void StopSmoking()
+    {
+        Debug.Log("Stopped Smoking!");
+    }
+    
 }


### PR DESCRIPTION
Progress will not start until all components are running.

Components now have a few new variables and methods to handle breaking.

A random float between minBreakTime and maxBreakTime is chosen whenever the object enters the running state (on Fix()). This timer determines how long until the component breaks. 

There is also another variable to handle toggling a boolean when the component is close to breaking. There is a timer threshold to control when the component starts "smoking".