### PR TITLE
MMM-32: Turn Act Data into ScriptableObject

### DIFF
--- a/Assets/ActProperties.cs
+++ b/Assets/ActProperties.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "Data", menuName = "ScriptableObjects/ActProperties", order = 1)]
+public class ActProperties : ScriptableObject
+{
+    
+    [Header("Progress Variables")]
+
+    public int WinThreshold = 100;
+
+    public int LoseThreshold = 0;
+
+    public int StartingProgress = 50;
+
+    [Range(0, 5)]
+    public int ActIndex = 0;
+    
+    public float TickTime = 1.0f;
+}

--- a/Assets/ActProperties.cs.meta
+++ b/Assets/ActProperties.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c27d573e635157c4296921ba813a3d4d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Managers/ActManager/ActManager.cs
+++ b/Assets/Managers/ActManager/ActManager.cs
@@ -30,7 +30,7 @@ public class ActManager : MonoBehaviour
 
     [Header("Progress Variables")] 
     
-    [SerializeField]
+    [SerializeField] // With Odin Inspector we could use InlineProperty for this
     private ActProperties actProperties;
     
     private int winThreshold;

--- a/Assets/Managers/ActManager/ActManager.cs
+++ b/Assets/Managers/ActManager/ActManager.cs
@@ -28,38 +28,40 @@ public class ActManager : MonoBehaviour
 
     private List<MechComponent> componentList = new List<MechComponent>();
 
-    [Header("Progress Variables")]
-
+    [Header("Progress Variables")] 
+    
     [SerializeField]
-    private int winThreshold = 100;
-
+    private ActProperties actProperties;
+    
+    private int winThreshold;
+    private int loseThreshold;
+    private int startingProgress;
+    
     [SerializeField]
-    private int loseThreshold = 0;
-
-    [SerializeField]
-    private int startingProgress = 50;
-
-    [SerializeField]
-    private int progressCounter = 0;
+    private int progressCounter;
 
 
     public enum ActState { Playing, Won, Lost };
     [SerializeField]
     public ActState actState = ActState.Playing;
 
-    [Range(0, 5)]
-    [SerializeField]
-    private int actIndex = 0;
+    private int actIndex;
 
 
     private float updateTimer = 0.0f;
-    private float tickTime = 1.0f;
+    private float tickTime;
 
 
     GUIStyle style;
 
     void Start()
     {
+        winThreshold = actProperties.WinThreshold;
+        loseThreshold = actProperties.LoseThreshold;
+        startingProgress = actProperties.StartingProgress;
+        tickTime = actProperties.TickTime;
+        actIndex = actProperties.ActIndex;
+        
         style = new GUIStyle();
         style.normal.textColor = Color.black;
 

--- a/Assets/Scenes/ActTest.unity
+++ b/Assets/Scenes/ActTest.unity
@@ -606,6 +606,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6367282095662397166, guid: 1e1f04c7ba92abb43aaa470f4ad7031b,
         type: 3}
+      propertyPath: actProperties
+      value: 
+      objectReference: {fileID: 11400000, guid: 377f1b56b42df654ea65fdef28fb717b,
+        type: 2}
+    - target: {fileID: 6367282095662397166, guid: 1e1f04c7ba92abb43aaa470f4ad7031b,
+        type: 3}
       propertyPath: progressManager
       value: 
       objectReference: {fileID: 2142661724}

--- a/Assets/Zone1Act1.asset
+++ b/Assets/Zone1Act1.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c27d573e635157c4296921ba813a3d4d, type: 3}
+  m_Name: Zone1Act1
+  m_EditorClassIdentifier: 
+  WinThreshold: 100
+  LoseThreshold: 0
+  StartingProgress: 50
+  ActIndex: 0
+  TickTime: 1

--- a/Assets/Zone1Act1.asset
+++ b/Assets/Zone1Act1.asset
@@ -16,4 +16,4 @@ MonoBehaviour:
   LoseThreshold: 0
   StartingProgress: 50
   ActIndex: 0
-  TickTime: 1
+  TickTime: 0.1

--- a/Assets/Zone1Act1.asset
+++ b/Assets/Zone1Act1.asset
@@ -16,4 +16,4 @@ MonoBehaviour:
   LoseThreshold: 0
   StartingProgress: 50
   ActIndex: 0
-  TickTime: 0.1
+  TickTime: 1

--- a/Assets/Zone1Act1.asset.meta
+++ b/Assets/Zone1Act1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 377f1b56b42df654ea65fdef28fb717b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Turned Act Data into a ScriptableObject.

Now data for acts (the act number, win and lose thresholds, how often ticks occur) are stored in their own asset files.

![image](https://github.com/Over-Easy-Games/MMM/assets/94721502/718c1559-a2fc-4ec4-8231-f13d012ab766)

![image](https://github.com/Over-Easy-Games/MMM/assets/94721502/e2054eec-4de3-4af0-82a3-7a742006ae11)
